### PR TITLE
Sashank 3d dev3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ PyFlex/bindings/examples/tmp
 PyFlex/bindings/examples/*.avi
 PyFlex/bindings/examples/*/
 PyFlex/bindings/examples/*.gif
+.vscode/*
 
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ PyFlex/bindings/build
 *.swp
 *.swo
 *.swn
-*.hdf5
 
 PyFlex/bindings/examples/tmp
 PyFlex/bindings/examples/*.avi

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ PyFlex/bindings/build
 *.swp
 *.swo
 *.swn
+*.hdf5
 
 PyFlex/bindings/examples/tmp
 PyFlex/bindings/examples/*.avi

--- a/PyFlex/bindings/pyflex.cpp
+++ b/PyFlex/bindings/pyflex.cpp
@@ -23,6 +23,7 @@ void pyflex_init(bool headless=false, bool render=true, int camera_width=720, in
     }
 
     g_scenes.push_back(new SoftgymCloth("Softgym Flag Cloth"));
+    g_scenes.push_back(new Softgym3dCloth("Softgym 3D Cloth"));
     g_scenes.push_back(new SoftgymFluid("Softgym Pour Water"));
     g_scenes.push_back(new SoftgymRope("Softgym Rope"));
     g_scenes.push_back(new SoftgymRigidCloth("Softgym Rigid Cloth"));

--- a/PyFlex/bindings/scenes.h
+++ b/PyFlex/bindings/scenes.h
@@ -28,6 +28,7 @@ public:
 };
 
 #include "softgym_scenes/softgym_cloth.h"
+#include "softgym_scenes/softgym_3dcloth.h"
 #include "softgym_scenes/softgym_fluid.h"
 #include "softgym_scenes/softgym_softbody.h"
 #include "softgym_scenes/softgym_rigid_cloth.h"

--- a/PyFlex/bindings/softgym_scenes/softgym_3dcloth.h
+++ b/PyFlex/bindings/softgym_scenes/softgym_3dcloth.h
@@ -1,0 +1,253 @@
+#pragma once
+#include <iostream>
+#include <vector>
+
+// inline void swap(int &a, int &b) {int tmp =a ; a = b; b=tmp;}
+void build_any_cloth(float* ptr, 
+                     int base, 
+                     float mass, 
+                     int node_num, 
+                     int face_num, 
+                     int stretch_edge_num, 
+                     int bend_edge_num, 
+                     int shear_edge_num,
+	                 float stretchStiffness, 
+                     float shearStiffness, 
+                     float bendStiffness, 
+                     bool compute_normal=true)
+{
+	int phase = NvFlexMakePhase(0, eNvFlexPhaseSelfCollide | eNvFlexPhaseSelfCollideFilter);
+
+	float x, y, z;
+	for (uint32_t i = 0; i < node_num; i++){
+		x = float(ptr[base + i * 3]);
+		y = float(ptr[base + i * 3 + 1]);
+		z = float(ptr[base + i * 3 + 2]);
+		cout << "add point x: " << x << " y: " << y << " z: " << z << endl;
+		g_buffers->positions.push_back(Vec4(x, y, z, 1. / mass));
+		g_buffers->velocities.push_back(Vec3(0, 0, 0));
+		g_buffers->phases.push_back(phase);
+	}
+	base = base + node_num * 3;
+	for (uint32_t i = 0; i < face_num; i++){
+		g_buffers->triangles.push_back(ptr[base + i*3]);
+		g_buffers->triangles.push_back(ptr[base + i*3+1]);
+		g_buffers->triangles.push_back(ptr[base + i*3+2]);
+		auto p1 = g_buffers->positions[ptr[base + i*3]];
+		auto p2 = g_buffers->positions[ptr[base + i*3+1]];
+		auto p3 = g_buffers->positions[ptr[base + i*3+2]];
+		auto normal = Vec3(0, 0, 0);
+		if (compute_normal) {
+			auto U = p2 - p1;
+			auto V = p3 - p1;
+			normal = Vec3(
+				U.y * V.z - U.z * V.y,
+				U.z * V.x - U.x * V.z,
+				U.x * V.y - U.y * V.x);
+		} else { // face normal is already computed outside
+			// cout << "using existing normal" << endl;
+			normal = Vec3(
+				ptr[base + i*3 + 3],
+				ptr[base + i*3 + 4],
+				ptr[base + i*3 + 5]);
+		}
+		g_buffers->triangleNormals.push_back(normal / Length(normal));
+	}
+
+	int sender, receiver;
+	if (!compute_normal) {
+		base = base + face_num*6;
+	} else {
+		base = base + face_num*3;
+	}
+	for (uint32_t i = 0; i < stretch_edge_num; i++ ){
+		sender = int(ptr[base + i * 2]);
+		receiver = int(ptr[base + i * 2 + 1]);
+		CreateSpring(sender, receiver, stretchStiffness); // assume no additional particles are added
+		// cout << "create stretch spring sender: " << sender << " receiver: " << receiver << endl;
+	}
+	base = base + stretch_edge_num*2;
+	for (uint32_t i=0; i< shear_edge_num; i++){
+		sender = int(ptr[base + i * 2]);
+		receiver = int(ptr[base + i * 2 + 1]);
+		CreateSpring(sender, receiver, shearStiffness);
+		// cout << "create shear spring sender: " << sender << " receiver: " << receiver << endl;
+	}
+
+	base += shear_edge_num*2;
+	for (uint32_t i = 0; i < bend_edge_num; i++){
+		sender = int(ptr[base + i * 2]);
+		receiver = int(ptr[base + i * 2 + 1]);
+		CreateSpring(sender, receiver, bendStiffness);
+		// cout << "create bend spring sender: " << sender << " receiver: " << receiver << endl;
+	}
+}
+
+class Softgym3dCloth : public Scene
+{
+public:
+    float cam_x;
+    float cam_y;
+    float cam_z;
+    float cam_angle_x;
+    float cam_angle_y;
+    float cam_angle_z;
+    int cam_width;
+    int cam_height;
+
+	Softgym3dCloth(const char* name) : Scene(name) {}
+
+    float get_param_float(py::array_t<float> scene_params, int idx)
+    {
+        auto ptr = (float *) scene_params.request().ptr;
+        float out = ptr[idx];
+        return out;
+    }
+
+    //params ordering: xpos, ypos, zpos, xsize, zsize, stretch, bend, shear
+    // render_type, cam_X, cam_y, cam_z, angle_x, angle_y, angle_z, width, height
+	void Initialize(py::array_t<float> scene_params, int thread_idx=0)
+    {
+        auto ptr = (float *) scene_params.request().ptr;
+	    float initX = ptr[0];
+	    float initY = ptr[1];
+	    float initZ = ptr[2];
+
+		int dimx = (int)ptr[3];
+		int dimz = (int)ptr[4];
+		float radius = 0.00625f;
+
+        int render_type = ptr[8]; // 0: only points, 1: only mesh, 2: points + mesh
+
+        cam_x = ptr[9];
+        cam_y = ptr[10];
+        cam_z = ptr[11];
+        cam_angle_x = ptr[12];
+        cam_angle_y = ptr[13];
+        cam_angle_z = ptr[14];
+        cam_width = int(ptr[15]);
+        cam_height = int(ptr[16]);
+
+        // Cloth
+        float stretchStiffness = ptr[5]; //0.9f;
+		float bendStiffness = ptr[6]; //1.0f;
+		float shearStiffness = ptr[7]; //0.9f;
+		int phase = NvFlexMakePhase(0, eNvFlexPhaseSelfCollide | eNvFlexPhaseSelfCollideFilter);
+		float mass = float(ptr[17])/(dimx*dimz);	// avg bath towel is 500-700g
+        int flip_mesh = int(ptr[18]); // Flip half
+        int vertice_num = int(ptr[19]); // Flip half
+        int face_num = int(ptr[20]); // Flip half
+        int stretch_num = int(ptr[21]); // Flip half
+        int bend_num = int(ptr[22]); // Flip half
+        int shear_num = int(ptr[23]); // Flip half
+        int base = 24;
+        build_any_cloth(ptr, 
+                        base, 
+                        mass, 
+                        vertice_num,
+                        face_num,
+                        stretch_num,
+                        bend_num,
+                        shear_num,
+                        stretchStiffness,
+                        shearStiffness,
+                        bendStiffness);
+	    // CreateSpringGrid(Vec3(initX, -initY, initZ), dimx, dimz, 1, radius, phase, stretchStiffness, bendStiffness, shearStiffness, 0.0f, 1.0f/mass);
+// 	    // Flip the last half of the mesh for the folding task
+// 	    if (flip_mesh)
+// 	    {
+// 	        int size = g_buffers->triangles.size();
+// //	        for (int j=int((dimz-1)*3/8); j<int((dimz-1)*5/8); ++j)
+// //	            for (int i=int((dimx-1)*1/8); i<int((dimx-1)*3/8); ++i)
+// //	            {
+// //	                int idx = j *(dimx-1) + i;
+// //
+// //	                if ((i!=int((dimx-1)*3/8-1)) && (j!=int((dimz-1)*3/8)))
+// //	                    swap(g_buffers->triangles[idx* 3 * 2], g_buffers->triangles[idx*3*2+1]);
+// //	                if ((i != int((dimx-1)*1/8)) && (j!=int((dimz-1)*5/8)-1))
+// //	                    swap(g_buffers->triangles[idx* 3 * 2 +3], g_buffers->triangles[idx*3*2+4]);
+// //                }
+// 	        for (int j=0; j<int((dimz-1)); ++j)
+// 	            for (int i=int((dimx-1)*1/8); i<int((dimx-1)*1/8)+5; ++i)
+// 	            {
+// 	                int idx = j *(dimx-1) + i;
+
+// 	                if ((i!=int((dimx-1)*1/8+4)))
+// 	                    swap(g_buffers->triangles[idx* 3 * 2], g_buffers->triangles[idx*3*2+1]);
+// 	                if ((i != int((dimx-1)*1/8)))
+// 	                    swap(g_buffers->triangles[idx* 3 * 2 +3], g_buffers->triangles[idx*3*2+4]);
+//                 }
+//         }
+		// g_numSubsteps = 4;
+		g_params.numIterations = 30;
+
+		g_params.dynamicFriction = 0.75f;
+		g_params.particleFriction = 1.0f;
+		g_params.damping = 1.0f;
+		g_params.sleepThreshold = 0.02f;
+
+		g_params.relaxationFactor = 1.0f;
+		g_params.shapeCollisionMargin = 0.04f;
+
+		g_sceneLower = Vec3(-1.0f);
+		g_sceneUpper = Vec3(1.0f);
+		g_drawPoints = false;
+
+        g_params.radius = radius*1.8f;
+        g_params.collisionDistance = 0.005f;
+
+        g_drawPoints = render_type & 1;
+        g_drawCloth = (render_type & 2) >>1;
+        g_drawSprings = false;
+
+
+        // table
+//        NvFlexRigidShape table;
+        // Half x, y, z
+//        NvFlexMakeRigidBoxShape(&table, -1, 0.27f, 0.55f, 0.3f, NvFlexMakeRigidPose(Vec3(-0.04f, 0.0f, 0.0f), Quat()));
+//        table.filter = 0;
+//        table.material.friction = 0.95f;
+//		table.user = UnionCast<void*>(AddRenderMaterial(Vec3(0.35f, 0.45f, 0.65f)));
+
+//        float density = 1000.0f;
+//        NvFlexRigidBody body;
+//		NvFlexMakeRigidBody(g_flexLib, &body, Vec3(1.0f, 1.0f, 0.0f), Quat(), &table, &density, 1);
+//
+//        g_buffers->rigidShapes.push_back(table);
+//        g_buffers->rigidBodies.push_back(body);
+
+        // Box object
+//        float scaleBox = 0.05f;
+//        float densityBox = 2000000000.0f;
+
+//        Mesh* boxMesh = ImportMesh(make_path(boxMeshPath, "/data/box.ply"));
+//        boxMesh->Transform(ScaleMatrix(scaleBox));
+//
+//        NvFlexTriangleMeshId boxId = CreateTriangleMesh(boxMesh, 0.00125f);
+//
+//        NvFlexRigidShape box;
+//        NvFlexMakeRigidTriangleMeshShape(&box, g_buffers->rigidBodies.size(), boxId, NvFlexMakeRigidPose(0, 0), 1.0f, 1.0f, 1.0f);
+//        box.filter = 0x0;
+//        box.material.friction = 1.0f;
+//        box.material.torsionFriction = 0.1;
+//        box.material.rollingFriction = 0.0f;
+//        box.thickness = 0.00125f;
+//
+//        NvFlexRigidBody boxBody;
+//        NvFlexMakeRigidBody(g_flexLib, &boxBody, Vec3(0.21f, 0.7f, -0.1375f), Quat(), &box, &density, 1);
+//
+//        g_buffers->rigidBodies.push_back(boxBody);
+//        g_buffers->rigidShapes.push_back(box);
+
+//        g_params.numPostCollisionIterations = 15;
+
+    }
+
+    virtual void CenterCamera(void)
+    {
+        g_camPos = Vec3(cam_x, cam_y, cam_z);
+        g_camAngle = Vec3(cam_angle_x, cam_angle_y, cam_angle_z);
+        g_screenHeight = cam_height;
+        g_screenWidth = cam_width;
+    }
+};

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -55,7 +55,7 @@ def main():
     
     if env_name == 'ClothEnv3D':
         env = SOFTGYM_ENVS[args.env_name](**env_kwargs)
-        env.reset(start_flat=False)
+        env.reset(start_flat=False, category='shirt', idx=2)
     else:
         env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
         env.reset()

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -53,16 +53,16 @@ def main():
     if not env_kwargs['use_cached_states']:
         print('Waiting to generate environment variations. May take 1 minute for each variation...')
     
-    if env_name == 'flingbot' or env_name == 'square':
+    if env_name == 'flingbot' or env_name == 'square' or env_name == 'clothfunnels':
         env = SOFTGYM_ENVS[args.env_name](**env_kwargs)
-        env.reset(start_flat=True)
+        env.reset(start_flat=False)
     else:
         env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
         env.reset()
         frames = [env.get_image(args.img_size, args.img_size)]
 
     for i in range(env.horizon):
-        if env_name == 'flingbot' or env_name == 'square':
+        if env_name == 'flingbot' or env_name == 'square' or env_name == 'clothfunnels':
             action = np.array([[0,0,0],[0,0,0]])
             _, info = env.step(action)
         else:

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -7,6 +7,7 @@ from softgym.utils.normalized_env import normalize
 from softgym.utils.visualization import save_numpy_as_gif
 import pyflex
 from matplotlib import pyplot as plt
+from pathlib import Path
 
 
 def show_depth():
@@ -48,18 +49,29 @@ def main():
     env_kwargs['render'] = True
     env_kwargs['headless'] = args.headless
 
+    env_name = args.env_name
     if not env_kwargs['use_cached_states']:
         print('Waiting to generate environment variations. May take 1 minute for each variation...')
-    env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
-    env.reset()
+    
+    if env_name == 'ClothEnv3D':
+        env = SOFTGYM_ENVS[args.env_name](**env_kwargs)
+        env.reset()
+    else:
+        env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
+        env.reset()
+        frames = [env.get_image(args.img_size, args.img_size)]
+    breakpoint()
 
-    frames = [env.get_image(args.img_size, args.img_size)]
     for i in range(env.horizon):
-        action = env.action_space.sample()
+        if env_name == 'ClothEnv3D':
+            action = np.array([[0,0,0],[0,0,0]])
+            _, info = env.step(action)
+        else:
+            action = env.action_space.sample()
+            _, _, _, info = env.step(action, record_continuous_video=True, img_size=args.img_size)
+            frames.extend(info['flex_env_recorded_frames'])
         # By default, the environments will apply action repitition. The option of record_continuous_video provides rendering of all
         # intermediate frames. Only use this option for visualization as it increases computation.
-        _, _, _, info = env.step(action, record_continuous_video=True, img_size=args.img_size)
-        frames.extend(info['flex_env_recorded_frames'])
         if args.test_depth:
             show_depth()
 

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -55,7 +55,7 @@ def main():
     
     if env_name == 'ClothEnv3D':
         env = SOFTGYM_ENVS[args.env_name](**env_kwargs)
-        env.reset()
+        env.reset(start_flat=False)
     else:
         env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
         env.reset()

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -60,7 +60,6 @@ def main():
         env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
         env.reset()
         frames = [env.get_image(args.img_size, args.img_size)]
-    breakpoint()
 
     for i in range(env.horizon):
         if env_name == 'ClothEnv3D':

--- a/examples/random_env.py
+++ b/examples/random_env.py
@@ -53,16 +53,16 @@ def main():
     if not env_kwargs['use_cached_states']:
         print('Waiting to generate environment variations. May take 1 minute for each variation...')
     
-    if env_name == 'ClothEnv3D':
+    if env_name == 'flingbot' or env_name == 'square':
         env = SOFTGYM_ENVS[args.env_name](**env_kwargs)
-        env.reset(start_flat=False, category='shirt', idx=2)
+        env.reset(start_flat=True)
     else:
         env = normalize(SOFTGYM_ENVS[args.env_name](**env_kwargs))
         env.reset()
         frames = [env.get_image(args.img_size, args.img_size)]
 
     for i in range(env.horizon):
-        if env_name == 'ClothEnv3D':
+        if env_name == 'flingbot' or env_name == 'square':
             action = np.array([[0,0,0],[0,0,0]])
             _, info = env.step(action)
         else:

--- a/softgym/envs/cloth_env_3d.py
+++ b/softgym/envs/cloth_env_3d.py
@@ -82,6 +82,7 @@ class ClothEnv3D(FlexEnv):
         use_subgoals=False,
         fold_unfold_ratio=0,
         cached_states_path=None,
+        dataset_path = None,
         **kwargs
     ):
         self.cloth_particle_radius = particle_radius
@@ -95,6 +96,7 @@ class ClothEnv3D(FlexEnv):
         self.max_action_scale = max_action_scale # x z y 
         self.use_subgoals = use_subgoals
         self.fold_unfold_ratio = fold_unfold_ratio
+        self.dataset_path = dataset_path
         super().__init__(headless=headless, **kwargs)
 
         if cached_states_path is not None and self.use_cached_states:
@@ -124,6 +126,8 @@ class ClothEnv3D(FlexEnv):
         self.extrinsic_matrix = get_extrinsic_matrix(self)
         self.corner_idxs = self.get_corner_idxs()
         self.edge_idxs = self.get_edge_idxs()
+        self.action_space = self.action_tool.action_space
+        self.observation_space = np.zeros(10)
 
     def _sample_cloth_pose(self, pose_list):
         poses_path = random.sample(pose_list, 1)[0]

--- a/softgym/envs/cloth_env_3d.py
+++ b/softgym/envs/cloth_env_3d.py
@@ -419,34 +419,42 @@ class ClothEnv3D(FlexEnv):
             bend_edges_num = bend_edges.shape[0]
             shear_edges_num = shear_edges.shape[0]
         elif self.dataset_name == "flingbot":
-            if category and idx is not None:
-                pass
+            if category is not None:
+                if not np.any([x in category for x in ['large', 'normal', 'shirt']]):
+                    raise ValueError("Invalid category")
+                id_category = 0
+                while id_category < len(self.mesh_input_files):
+                    if category in str(self.mesh_input_files[id_category]):
+                        break
+                    id_category += 1
             else:
-                idx = np.random.randint(0, 3)
-                mesh_hdf5_path = self.mesh_input_files[idx]
-                with h5py.File(mesh_hdf5_path, 'r') as file:
+                id_category = np.random.randint(0, 3)
+            mesh_hdf5_path = self.mesh_input_files[id_category]
+            with h5py.File(mesh_hdf5_path, 'r') as file:
+                if idx is None:
                     idx = np.random.randint(0, len(file.keys()))
-                    data_dict = file[list(file.keys())[idx]] 
-                    config['ClothSize'] = data_dict['cloth_size'][:]
-                    config['ClothStiff'] = data_dict['cloth_stiff'][:]
-                    vertices = data_dict['mesh_verts'][:]
-                    if vertices.shape[0] == 0:
-                        env_idx = 0
-                    faces = data_dict['mesh_faces'][:]
-                    stretch_edges = data_dict['mesh_stretch_edges'][:]
-                    bend_edges = data_dict['mesh_bend_edges'][:]
-                    shear_edges = data_dict['mesh_shear_edges'][:]
-                    positions = data_dict['particle_pos'][:]
-                    vertices = vertices.astype(np.float32)
-                    faces = faces.astype(np.float32)
-                    stretch_edges = stretch_edges.astype(np.float32)
-                    bend_edges = bend_edges.astype(np.float32)
-                    shear_edges = shear_edges.astype(np.float32)
-                    vertices_num = vertices.shape[0] / 3
-                    faces_num = faces.shape[0] / 3
-                    stretch_edges_num = stretch_edges.shape[0] / 2
-                    bend_edges_num = bend_edges.shape[0] / 2
-                    shear_edges_num = shear_edges.shape[0] / 2
+                assert idx < len(file.keys()) and idx >= 0, "Invalid idx"
+                data_dict = file[list(file.keys())[idx]] 
+                config['ClothSize'] = data_dict['cloth_size'][:]
+                config['ClothStiff'] = data_dict['cloth_stiff'][:]
+                vertices = data_dict['mesh_verts'][:]
+                if vertices.shape[0] == 0:
+                    env_idx = 0
+                faces = data_dict['mesh_faces'][:]
+                stretch_edges = data_dict['mesh_stretch_edges'][:]
+                bend_edges = data_dict['mesh_bend_edges'][:]
+                shear_edges = data_dict['mesh_shear_edges'][:]
+                positions = data_dict['particle_pos'][:]
+                vertices = vertices.astype(np.float32)
+                faces = faces.astype(np.float32)
+                stretch_edges = stretch_edges.astype(np.float32)
+                bend_edges = bend_edges.astype(np.float32)
+                shear_edges = shear_edges.astype(np.float32)
+                vertices_num = vertices.shape[0] / 3
+                faces_num = faces.shape[0] / 3
+                stretch_edges_num = stretch_edges.shape[0] / 2
+                bend_edges_num = bend_edges.shape[0] / 2
+                shear_edges_num = shear_edges.shape[0] / 2
         scene_params = np.array([*config['ClothPos'], 
                                 *config['ClothSize'], 
                                 *config['ClothStiff'], 

--- a/softgym/envs/cloth_env_3d.py
+++ b/softgym/envs/cloth_env_3d.py
@@ -368,13 +368,16 @@ class ClothEnv3D(FlexEnv):
         }
         return obs
 
-    def set_scene(self):
+    def set_scene(self, category = None, idx = None):
+        if category is not None and idx is not None:
+            mesh_path = self.dataset_path / (category +'/' + str(idx).zfill(4) + '.obj')
+        else:
+            idx = np.random.randint(0, len(self.mesh_input_files))
+            mesh_path = self.mesh_input_files[idx]
         render_mode = 2  # cloth
         env_idx = 1
         config = self.config
         camera_params = config["camera_params"][config["camera_name"]]
-        idx = np.random.randint(0, len(self.mesh_input_files))
-        mesh_path = self.mesh_input_files[idx]
         vertices, faces, stretch_edges, bend_edges, shear_edges = load_cloth(mesh_path, 1.0)
         vertices = vertices.astype(np.float32)
         faces = faces.astype(np.float32)
@@ -410,8 +413,8 @@ class ClothEnv3D(FlexEnv):
         pyflex.set_positions(positions)
         pyflex.step()
 
-    def reset(self, flip_cloth=False, start_state=None, goal_state=None):
-        self.set_scene()
+    def reset(self, flip_cloth=False, start_state=None, goal_state=None, category=None, idx=None):
+        self.set_scene(category=category, idx=idx)
         self.particle_num = pyflex.get_n_particles()
         self.prev_reward = 0.0
         self.time_step = 0

--- a/softgym/registered_env.py
+++ b/softgym/registered_env.py
@@ -12,6 +12,7 @@ from softgym.envs.cloth_env_3d import ClothEnv3D
 from pathlib import Path
 
 from collections import OrderedDict
+import os
 
 env_arg_dict = {
     'PourWater': {'observation_mode': 'cam_rgb',
@@ -180,8 +181,8 @@ env_arg_dict = {
         num_variations=1000,
         deterministic=False
     ),
-    "ClothEnv3D": dict(
-        dataset_path=Path("/data/stirumal/datasets/flingbot"),
+    "flingbot": dict(
+        dataset_path=Path(os.getenv('FLINGBOT_DATASET_PATH')),
         observation_mode='point_cloud',
         action_mode='picker',
         num_pickers=1,
@@ -189,7 +190,15 @@ env_arg_dict = {
         headless=True,
         dataset_name = 'flingbot',
         split = 'test'
-    )
+    ),
+    "square": dict(
+        observation_mode='point_cloud',
+        action_mode='picker',
+        num_pickers=1,
+        render=True,
+        headless=True,
+        dataset_name = 'square',
+     )
 }
 
 SOFTGYM_ENVS = OrderedDict({
@@ -206,4 +215,6 @@ SOFTGYM_ENVS = OrderedDict({
     'RopeFlatten': RopeFlattenEnv,
     'RopeConfiguration': RopeConfigurationEnv,
     'ClothEnv3D': ClothEnv3D, 
+    'flingbot': ClothEnv3D, 
+    'square': ClothEnv3D, 
 })

--- a/softgym/registered_env.py
+++ b/softgym/registered_env.py
@@ -198,7 +198,17 @@ env_arg_dict = {
         render=True,
         headless=True,
         dataset_name = 'square',
-     )
+    ),
+    "clothfunnels": dict(
+        dataset_path=Path(os.getenv('CLOTHFUNNELS_DATASET_PATH')),
+        observation_mode='point_cloud',
+        action_mode='picker',
+        num_pickers=1,
+        render=True,
+        headless=True,
+        dataset_name = 'cloth-funnels',
+        split = 'test'
+    )
 }
 
 SOFTGYM_ENVS = OrderedDict({
@@ -217,4 +227,5 @@ SOFTGYM_ENVS = OrderedDict({
     'ClothEnv3D': ClothEnv3D, 
     'flingbot': ClothEnv3D, 
     'square': ClothEnv3D, 
+    'clothfunnels': ClothEnv3D, 
 })

--- a/softgym/registered_env.py
+++ b/softgym/registered_env.py
@@ -181,7 +181,7 @@ env_arg_dict = {
         deterministic=False
     ),
     "ClothEnv3D": dict(
-        dataset_path=Path("/data/stirumal/datasets/cloth3d/train/Jumpsuit"),
+        dataset_path=Path("/data/stirumal/datasets/cloth3d/train"),
         observation_mode='point_cloud',
         action_mode='picker',
         num_pickers=1,

--- a/softgym/registered_env.py
+++ b/softgym/registered_env.py
@@ -181,12 +181,14 @@ env_arg_dict = {
         deterministic=False
     ),
     "ClothEnv3D": dict(
-        dataset_path=Path("/data/stirumal/datasets/cloth3d/train"),
+        dataset_path=Path("/data/stirumal/datasets/flingbot"),
         observation_mode='point_cloud',
         action_mode='picker',
         num_pickers=1,
         render=True,
         headless=True,
+        dataset_name = 'flingbot',
+        split = 'test'
     )
 }
 

--- a/softgym/registered_env.py
+++ b/softgym/registered_env.py
@@ -8,6 +8,8 @@ from softgym.envs.cloth_fold import ClothFoldEnv
 from softgym.envs.cloth_drop import ClothDropEnv
 from softgym.envs.cloth_fold_crumpled import ClothFoldCrumpledEnv
 from softgym.envs.cloth_fold_drop import ClothFoldDropEnv
+from softgym.envs.cloth_env_3d import ClothEnv3D 
+from pathlib import Path
 
 from collections import OrderedDict
 
@@ -178,6 +180,14 @@ env_arg_dict = {
         num_variations=1000,
         deterministic=False
     ),
+    "ClothEnv3D": dict(
+        dataset_path=Path("/data/stirumal/datasets/cloth3d/train/Jumpsuit"),
+        observation_mode='point_cloud',
+        action_mode='picker',
+        num_pickers=1,
+        render=True,
+        headless=True,
+    )
 }
 
 SOFTGYM_ENVS = OrderedDict({
@@ -193,4 +203,5 @@ SOFTGYM_ENVS = OrderedDict({
     'ClothFoldCrumpled': ClothFoldCrumpledEnv,
     'RopeFlatten': RopeFlattenEnv,
     'RopeConfiguration': RopeConfigurationEnv,
+    'ClothEnv3D': ClothEnv3D, 
 })

--- a/softgym/tests/test_cloth3d.py
+++ b/softgym/tests/test_cloth3d.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pyflex
 import time
@@ -119,7 +120,7 @@ if __name__ == "__main__":
     camera_width = 720
     camera_height = 720
     render = True
-    dataset_path = Path("/data/stirumal/datasets/cloth3d/train/Jumpsuit")
+    dataset_path = Path(os.getenv('FLINBOT_DATASET_PATH'))
     breakpoint()
     idx = "0001.obj"
     mesh_path = dataset_path / idx

--- a/softgym/tests/test_cloth3d.py
+++ b/softgym/tests/test_cloth3d.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pyflex
+import time
+if __name__ == "__main__":
+
+    particle_radius=0.00625
+    cam_pos, cam_angle = np.array([-0.0, 1.5, 0.0]), np.array(
+            [0, -np.pi / 2.0, 0.0]
+        )
+    render_mode = 2
+    env3d = False 
+    envDrop = True
+    if env3d:
+        config = {
+                "ClothPos": [-0.15, 0.0, -0.15],
+                "ClothSize": [int(0.30 / particle_radius), int(0.30 / particle_radius)],
+                "ClothStiff": [
+                    2.0,
+                    0.5,
+                    1.0,
+                ],  # Stretch, Bend and Shear #0.8, 1., 0.9 #1.0, 1.3, 0.9
+                "mass": 0.0054,
+                "camera_name": "default_camera",
+                "camera_params": {
+                    "default_camera": {
+                        "pos": cam_pos,
+                        "angle": cam_angle,
+                        "width": 720,
+                        "height": 720,
+                    }
+                },
+                "flip_mesh": 0,
+                "drop_height": 0.0,
+            }
+    elif envDrop:
+        config = {
+            'ClothPos': [-1.6, 2.0, -0.8],
+            'ClothSize': [64, 32],
+            'ClothStiff': [0.9, 1.0, 0.9],  # Stretch, Bend and Shear
+            'camera_name': 'default_camera',
+            'camera_params': {'default_camera':
+                                  {'pos': np.array([1.07199, 0.94942, 1.15691]),
+                                   'angle': np.array([0.633549, -0.397932, 0]),
+                                   'width': 720,
+                                   'height': 720}},
+            'flip_mesh': 0,
+            'mass': 0.0054,
+        }
+    mass = config['mass']
+    camera_params = config['camera_params'][config['camera_name']]
+    scene_params = np.array([*config['ClothPos'], *config['ClothSize'], *config['ClothStiff'], render_mode,
+                                 *camera_params['pos'][:], *camera_params['angle'][:], camera_params['width'], camera_params['height'], mass,
+                                 config['flip_mesh']])
+    headless = False
+    camera_width = 720
+    camera_height = 720
+    render = True
+    pyflex.init(headless, render, camera_width, camera_height)
+    pyflex.set_scene(0, scene_params, 0)
+    x = 1
+    while x < 1000:
+        pyflex.step()
+        pyflex.render()
+        time.sleep(0.05)
+        x += 1
+    pass

--- a/softgym/tests/test_cloth3d.py
+++ b/softgym/tests/test_cloth3d.py
@@ -120,6 +120,7 @@ if __name__ == "__main__":
     camera_height = 720
     render = True
     dataset_path = Path("/data/stirumal/datasets/cloth3d/train/Jumpsuit")
+    breakpoint()
     idx = "0001.obj"
     mesh_path = dataset_path / idx
     vertices, faces, stretch_edges, bend_edges, shear_edges = load_cloth(mesh_path, 1.0)

--- a/softgym/tests/test_cloth3d.py
+++ b/softgym/tests/test_cloth3d.py
@@ -75,8 +75,8 @@ if __name__ == "__main__":
             [0, -np.pi / 2.0, 0.0]
         )
     render_mode = 2
-    env3d = False 
-    envDrop = True
+    env3d = True
+    envDrop = False 
     if env3d:
         config = {
                 "ClothPos": [-0.15, 0.0, -0.15],
@@ -86,7 +86,7 @@ if __name__ == "__main__":
                     0.5,
                     1.0,
                 ],  # Stretch, Bend and Shear #0.8, 1., 0.9 #1.0, 1.3, 0.9
-                "mass": 0.0054,
+                "mass": 0.54,
                 "camera_name": "default_camera",
                 "camera_params": {
                     "default_camera": {
@@ -115,24 +115,47 @@ if __name__ == "__main__":
         }
     mass = config['mass']
     camera_params = config['camera_params'][config['camera_name']]
-    scene_params = np.array([*config['ClothPos'], *config['ClothSize'], *config['ClothStiff'], render_mode,
-                                 *camera_params['pos'][:], *camera_params['angle'][:], camera_params['width'], camera_params['height'], mass,
-                                 config['flip_mesh']])
     headless = False
     camera_width = 720
     camera_height = 720
     render = True
-    dataset_path = Path("/data/stirumal/datasets/cloth3d/train/Tshirt")
+    dataset_path = Path("/data/stirumal/datasets/cloth3d/train/Jumpsuit")
     idx = "0001.obj"
     mesh_path = dataset_path / idx
     vertices, faces, stretch_edges, bend_edges, shear_edges = load_cloth(mesh_path, 1.0)
-    breakpoint()
-    # pyflex.init(headless, render, camera_width, camera_height)
-    # pyflex.set_scene(0, scene_params, 0)
-    # x = 1
-    # while x < 1000:
-    #     pyflex.step()
-    #     pyflex.render()
-    #     time.sleep(0.05)
-    #     x += 1
-    # pass
+    # breakpoint()
+    env_idx = 1
+    vertices = vertices.astype(np.float32)
+    faces = faces.astype(np.float32)
+    stretch_edges = stretch_edges.astype(np.float32)
+    bend_edges = bend_edges.astype(np.float32)
+    shear_edges = shear_edges.astype(np.float32)
+    scene_params = np.array([*config['ClothPos'], 
+                             *config['ClothSize'], 
+                             *config['ClothStiff'], 
+                              render_mode,
+                             *camera_params['pos'][:], 
+                             *camera_params['angle'][:], 
+                              camera_params['width'], 
+                              camera_params['height'], 
+                              mass,
+                              config['flip_mesh'], 
+                              vertices.shape[0], 
+                              faces.shape[0],
+                              stretch_edges.shape[0],
+                              bend_edges.shape[0],
+                              shear_edges.shape[0],
+                              *vertices.reshape(-1),
+                              *faces.reshape(-1),
+                              *stretch_edges.reshape(-1),
+                              *bend_edges.reshape(-1),
+                              *shear_edges.reshape(-1)])
+    pyflex.init(headless, render, camera_width, camera_height)
+    pyflex.set_scene(env_idx, scene_params, 0)
+    x = 1
+    while x < 1000:
+        pyflex.step()
+        pyflex.render()
+        time.sleep(0.05)
+        x += 1
+    pass

--- a/softgym/tests/test_clothfunnels.py
+++ b/softgym/tests/test_clothfunnels.py
@@ -1,0 +1,108 @@
+import os
+import numpy as np
+import pyflex
+import time
+from pathlib import Path
+import h5py
+
+if __name__ == "__main__":
+
+    particle_radius=0.00625
+    cam_pos, cam_angle = np.array([-0.0, 1.5, 0.0]), np.array(
+            [0, -np.pi / 2.0, 0.0]
+        )
+    render_mode = 2
+    env3d = True
+    envDrop = False 
+    if env3d:
+        config = {
+                "ClothPos": [-0.15, 0.0, -0.15],
+                "ClothSize": [int(0.30 / particle_radius), int(0.30 / particle_radius)],
+                "ClothStiff": [
+                    2.0,
+                    0.5,
+                    1.0,
+                ],  # Stretch, Bend and Shear #0.8, 1., 0.9 #1.0, 1.3, 0.9
+                "mass": 0.54,
+                "camera_name": "default_camera",
+                "camera_params": {
+                    "default_camera": {
+                        "pos": cam_pos,
+                        "angle": cam_angle,
+                        "width": 720,
+                        "height": 720,
+                    }
+                },
+                "flip_mesh": 0,
+                "drop_height": 0.0,
+            }
+    elif envDrop:
+        config = {
+            'ClothPos': [-1.6, 2.0, -0.8],
+            'ClothSize': [64, 32],
+            'ClothStiff': [0.9, 1.0, 0.9],  # Stretch, Bend and Shear
+            'camera_name': 'default_camera',
+            'camera_params': {'default_camera':
+                                  {'pos': np.array([1.07199, 0.94942, 1.15691]),
+                                   'angle': np.array([0.633549, -0.397932, 0]),
+                                   'width': 720,
+                                   'height': 720}},
+            'flip_mesh': 0,
+            'mass': 0.0054,
+        }
+    mass = config['mass']
+    camera_params = config['camera_params'][config['camera_name']]
+    headless = False
+    camera_width = 720
+    camera_height = 720
+    render = True
+
+    cfp = os.getenv('CLOTHFUNNELS_SLEEVE_PATH')
+    idx = 0
+    with h5py.File(cfp, 'r') as file:
+        data_dict = file[list(file.keys())[idx]] 
+        vertices = data_dict['mesh_verts'][:]
+        faces = data_dict['mesh_faces'][:]
+        stretch_edges = data_dict['mesh_stretch_edges'][:]
+        bend_edges = data_dict['mesh_bend_edges'][:]
+        shear_edges = data_dict['mesh_shear_edges'][:]
+        positions = data_dict['particle_pos'][:]
+        pass
+    
+    # breakpoint()
+    env_idx = 1
+    vertices = vertices.astype(np.float32)
+    faces = faces.astype(np.float32)
+    stretch_edges = stretch_edges.astype(np.float32)
+    bend_edges = bend_edges.astype(np.float32)
+    shear_edges = shear_edges.astype(np.float32)
+    scene_params = np.array([*config['ClothPos'], 
+                             *config['ClothSize'], 
+                             *config['ClothStiff'], 
+                              render_mode,
+                             *camera_params['pos'][:], 
+                             *camera_params['angle'][:], 
+                              camera_params['width'], 
+                              camera_params['height'], 
+                              mass,
+                              config['flip_mesh'], 
+                              vertices.shape[0]/3, 
+                              faces.shape[0]/3,
+                              stretch_edges.shape[0]/2,
+                              bend_edges.shape[0]/2,
+                              shear_edges.shape[0]/2,
+                              *vertices.reshape(-1),
+                              *faces.reshape(-1),
+                              *stretch_edges.reshape(-1),
+                              *bend_edges.reshape(-1),
+                              *shear_edges.reshape(-1)])
+    pyflex.init(headless, render, camera_width, camera_height)
+    pyflex.set_scene(env_idx, scene_params, 0)
+    pyflex.set_positions(positions.astype(np.float32))
+    x = 1
+    while x < 1000:
+        pyflex.step()
+        pyflex.render()
+        time.sleep(0.05)
+        x += 1
+    pass

--- a/softgym/tests/test_flingbot.py
+++ b/softgym/tests/test_flingbot.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     render = True
 
     flingbot_shirt_path = '/home/sashank/projects/softgym/flingbot-shirt-eval.hdf5'
-    idx = 0
+    idx = 4
     with h5py.File(flingbot_shirt_path, 'r') as file:
         data_dict = file[list(file.keys())[idx]] 
         vertices = data_dict['mesh_verts'][:]

--- a/softgym/tests/test_flingbot.py
+++ b/softgym/tests/test_flingbot.py
@@ -1,0 +1,172 @@
+import numpy as np
+import pyflex
+import time
+from pathlib import Path
+import h5py
+
+def load_cloth(path, scale=1.0):
+    """Load .obj of cloth mesh. Only quad-mesh is acceptable!
+    Return:
+        - vertices: ndarray, (N, 3)
+        - triangle_faces: ndarray, (S, 3)
+        - stretch_edges: ndarray, (M1, 2)
+        - bend_edges: ndarray, (M2, 2)
+        - shear_edges: ndarray, (M3, 2)
+    This function was written by Zhenjia Xu
+    email: xuzhenjia [at] cs (dot) columbia (dot) edu
+    website: https://www.zhenjiaxu.com/
+    """
+    # print("load cloth from: ", path)
+    vertices, faces = [], []
+    with open(path, 'r') as f:
+        lines = f.readlines()
+    for line in lines:
+        # 3D vertex
+        if line.startswith('v '):
+            vertices.append([float(n)
+                             for n in line.replace('v ', '').split(' ')])
+        # Face
+        elif line.startswith('f '):
+            idx = [n.split('/') for n in line.replace('f ', '').split(' ')]
+            face = [int(n[0]) - 1 for n in idx]
+            assert(len(face) == 4)
+            faces.append(face)
+
+    triangle_faces = []
+    for face in faces:
+        triangle_faces.append([face[0], face[1], face[2]])
+        triangle_faces.append([face[0], face[2], face[3]])
+
+    stretch_edges, shear_edges, bend_edges = set(), set(), set()
+
+    # Stretch & Shear
+    for face in faces:
+        stretch_edges.add(tuple(sorted([face[0], face[1]])))
+        stretch_edges.add(tuple(sorted([face[1], face[2]])))
+        stretch_edges.add(tuple(sorted([face[2], face[3]])))
+        stretch_edges.add(tuple(sorted([face[3], face[0]])))
+
+        shear_edges.add(tuple(sorted([face[0], face[2]])))
+        shear_edges.add(tuple(sorted([face[1], face[3]])))
+
+    # Bend
+    neighbours = dict()
+    for vid in range(len(vertices)):
+        neighbours[vid] = set()
+    for edge in stretch_edges:
+        neighbours[edge[0]].add(edge[1])
+        neighbours[edge[1]].add(edge[0])
+    for vid in range(len(vertices)):
+        neighbour_list = list(neighbours[vid])
+        N = len(neighbour_list)
+        for i in range(N - 1):
+            for j in range(i+1, N):
+                bend_edge = tuple(
+                    sorted([neighbour_list[i], neighbour_list[j]]))
+                if bend_edge not in shear_edges:
+                    bend_edges.add(bend_edge)
+
+    return np.array(vertices) * scale, np.array(triangle_faces),\
+        np.array(list(stretch_edges)), np.array(
+            list(bend_edges)), np.array(list(shear_edges))
+if __name__ == "__main__":
+
+    particle_radius=0.00625
+    cam_pos, cam_angle = np.array([-0.0, 1.5, 0.0]), np.array(
+            [0, -np.pi / 2.0, 0.0]
+        )
+    render_mode = 2
+    env3d = True
+    envDrop = False 
+    if env3d:
+        config = {
+                "ClothPos": [-0.15, 0.0, -0.15],
+                "ClothSize": [int(0.30 / particle_radius), int(0.30 / particle_radius)],
+                "ClothStiff": [
+                    2.0,
+                    0.5,
+                    1.0,
+                ],  # Stretch, Bend and Shear #0.8, 1., 0.9 #1.0, 1.3, 0.9
+                "mass": 0.54,
+                "camera_name": "default_camera",
+                "camera_params": {
+                    "default_camera": {
+                        "pos": cam_pos,
+                        "angle": cam_angle,
+                        "width": 720,
+                        "height": 720,
+                    }
+                },
+                "flip_mesh": 0,
+                "drop_height": 0.0,
+            }
+    elif envDrop:
+        config = {
+            'ClothPos': [-1.6, 2.0, -0.8],
+            'ClothSize': [64, 32],
+            'ClothStiff': [0.9, 1.0, 0.9],  # Stretch, Bend and Shear
+            'camera_name': 'default_camera',
+            'camera_params': {'default_camera':
+                                  {'pos': np.array([1.07199, 0.94942, 1.15691]),
+                                   'angle': np.array([0.633549, -0.397932, 0]),
+                                   'width': 720,
+                                   'height': 720}},
+            'flip_mesh': 0,
+            'mass': 0.0054,
+        }
+    mass = config['mass']
+    camera_params = config['camera_params'][config['camera_name']]
+    headless = False
+    camera_width = 720
+    camera_height = 720
+    render = True
+
+    flingbot_shirt_path = '/home/sashank/projects/softgym/flingbot-shirt-eval.hdf5'
+    idx = 0
+    with h5py.File(flingbot_shirt_path, 'r') as file:
+        data_dict = file[list(file.keys())[idx]] 
+        vertices = data_dict['mesh_verts'][:]
+        faces = data_dict['mesh_faces'][:]
+        stretch_edges = data_dict['mesh_stretch_edges'][:]
+        bend_edges = data_dict['mesh_bend_edges'][:]
+        shear_edges = data_dict['mesh_shear_edges'][:]
+        positions = data_dict['particle_pos'][:]
+        pass
+    
+    # breakpoint()
+    env_idx = 1
+    vertices = vertices.astype(np.float32)
+    faces = faces.astype(np.float32)
+    stretch_edges = stretch_edges.astype(np.float32)
+    bend_edges = bend_edges.astype(np.float32)
+    shear_edges = shear_edges.astype(np.float32)
+    scene_params = np.array([*config['ClothPos'], 
+                             *config['ClothSize'], 
+                             *config['ClothStiff'], 
+                              render_mode,
+                             *camera_params['pos'][:], 
+                             *camera_params['angle'][:], 
+                              camera_params['width'], 
+                              camera_params['height'], 
+                              mass,
+                              config['flip_mesh'], 
+                              vertices.shape[0]/3, 
+                              faces.shape[0]/3,
+                              stretch_edges.shape[0]/2,
+                              bend_edges.shape[0]/2,
+                              shear_edges.shape[0]/2,
+                              *vertices.reshape(-1),
+                              *faces.reshape(-1),
+                              *stretch_edges.reshape(-1),
+                              *bend_edges.reshape(-1),
+                              *shear_edges.reshape(-1)])
+    pyflex.init(headless, render, camera_width, camera_height)
+    pyflex.set_scene(env_idx, scene_params, 0)
+    pyflex.set_positions(positions.astype(np.float32))
+    x = 1
+    while x < 1000:
+        pyflex.step()
+        pyflex.render()
+        time.sleep(0.05)
+        x += 1
+    pass

--- a/softgym/tests/test_flingbot.py
+++ b/softgym/tests/test_flingbot.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pyflex
 import time
@@ -121,7 +122,7 @@ if __name__ == "__main__":
     camera_height = 720
     render = True
 
-    flingbot_shirt_path = '/home/sashank/projects/softgym/flingbot-shirt-eval.hdf5'
+    flingbot_shirt_path = os.getenv('FLINGBOT_SHIRT_PATH')
     idx = 4
     with h5py.File(flingbot_shirt_path, 'r') as file:
         data_dict = file[list(file.keys())[idx]] 


### PR DESCRIPTION
Made the required changes. 
You can use this code by calling:
```python
ClothEnv3D(dataset_path=Path(os.getenv('FLINGBOT_DATASET_PATH')),
        observation_mode='point_cloud',
        action_mode='picker',
        num_pickers=1,
        render=True,
        headless=True,
        dataset_name = 'flingbot',
        split = 'test')
```

 for a flingbot environment
and 
```python
ClothEnv3D(observation_mode='point_cloud',
        action_mode='picker',
        num_pickers=1,
        render=True,
        headless=True,
        dataset_name = 'square')
```
 for the original environment
.
`env.reset` will simply randomly initialize a mesh in the flat state. 
`env.reset(start_flat=False)` for a FlingBot environment will initialize a random flingbot cloth with the same starting states as flingbot
`env.reset(category='shirt', idx = 2)` will initialize the mesh in shirt category with id 2. Not providing either of these values will lead to a random initialization of that value (category or shirt) respectively. 
If you create a square environment, here is how it looks:
![image](https://github.com/thomasweng15/softgym/assets/25933381/bdba9698-ea0d-4cd0-bf3f-7410adb5a0c5)
If you create a flingbot environment, here are some pictures:
![image](https://github.com/thomasweng15/softgym/assets/25933381/91b50cbf-b22e-43af-8893-353a3817e500)
![image](https://github.com/thomasweng15/softgym/assets/25933381/5877c0fe-0267-43bb-9167-cc89c3d18e94)
![image](https://github.com/thomasweng15/softgym/assets/25933381/0889f2ae-dd7c-4489-a465-abf3439b5a01)
If you set flat state false then you get the same start crumple as flingbot:
![image](https://github.com/thomasweng15/softgym/assets/25933381/a944bf80-8ff8-4f6a-bfe1-0058df3f7d6e)
